### PR TITLE
解決部份車種空白的問題

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,9 +1,9 @@
 $(function () {
-  
+
   'use strict';
-  
+
   Vue.component('select2', VueSelect2);
-  
+
   const updatespeed = 60000;
 
   const trainType = {"1115":"莒光號", //（有身障座位 ,有自行車車廂）
@@ -59,7 +59,7 @@ $(function () {
               children: children
             });
           });
-          
+
           state.stationsOfLine = arr;
         }); //取全台車站 (local data)
       },
@@ -101,7 +101,7 @@ $(function () {
     created() {
       store.commit('getLinesAndStations'); //取線路名稱 (local data)
       store.commit('getLiveBoardByStationID', this.selectedStation);
-      
+
       // 一分鐘自動更新一次
       setInterval(()=>{
         store.commit('getLiveBoardByStationID', this.selectedStation);
@@ -124,6 +124,25 @@ $(function () {
       },
       getDailyTimetable: function() {
         store.commit('getDailyTimetable', this.selectedStation);
+      }
+    },
+    filters: {
+
+      /**
+       * Trim train class description
+       */
+      trainClass: function (t) {
+
+        // If TRA left train class name blank, use English name instead
+        t = (t.Zh_tw) ? t.Zh_tw : t.En
+
+        let r = t.replace(/自強\(普悠瑪\)/g, '普悠瑪').replace(/自強\(太魯閣\)/g, '太魯閣')
+          .replace(/自強\(DMU2800、2900、3000型柴聯及 EMU型電車自強號\)/g, '自強')
+          .replace(/區間快/g, '區間快車').replace(/.*(Chu-Kuang).*/g, '莒光').replace(/.*(Tze-Chiang).*/g, '自強')
+          .replace(/\(.+\)/g, '') || '其他';
+
+        return r;
+
       }
     }
   });
@@ -167,7 +186,7 @@ $(function () {
             dTime.setMinutes(item.ScheduledDepartureTime.split(':')[1]);
             return dTime.getTime() + (item.DelayTime * 60 * 1000) >= now;
           });
-	  
+
 
           // 將資料分成順行逆行兩個部分
           let clockwise = json.filter(item=>item.Direction == 0);

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <meta name="twitter:title" content="台鐵列車即時車況">
   <meta name="twitter:description" content="選擇上車的車站，查詢台鐵列車的即時車況">
   <meta name="twitter:image" content="http://app.boggy.tw/livetra/assets/images/sns_share_img.jpg">
-  
+
   <meta property="og:type" content="website">
   <meta property="og:title" content="台鐵列車即時車況">
   <meta property="og:description" content="選擇上車的車站，查詢台鐵列車的即時車況">
@@ -48,7 +48,7 @@
   <div class="container">
     <div class="train_app" v-cloak>
       <select2 :options="this.$store.state.stationsOfLine" v-model="selectedStation" style="width: 100%"></select2>
-      
+
       <h3 class="direction-title">順行</h3>
       <div class="list-group">
         <div class="list-group-item" v-if="!this.$store.state.liveBoard.clockwise.length">
@@ -60,7 +60,7 @@
               <div class="col list-group-item-left-col">
                 <span class="badge badge-default">{{ liveboard.ScheduledDepartureTime.replace(':00', '') }}</span>
                 開往 {{ liveboard.EndingStationName.Zh_tw }}
-                <a href="#" v-on:click="showTrainInfo(liveboard.TrainNo)">{{ liveboard.TrainNo }}</a> 車次 
+                <a href="#" v-on:click="showTrainInfo(liveboard.TrainNo)">{{ liveboard.TrainNo }}</a> 車次
                 {{ getTrainTypeByID(liveboard.TrainClassificationID) }}
               </div>
               <div class="col list-group-item-right-col">
@@ -87,7 +87,7 @@
               <div class="col list-group-item-left-col">
                 <span class="badge badge-default">{{ liveboard.ScheduledDepartureTime.replace(':00', '') }}</span>
                 開往 {{ liveboard.EndingStationName.Zh_tw }}
-                <a href="#" v-on:click="showTrainInfo(liveboard.TrainNo)">{{ liveboard.TrainNo }}</a> 車次 
+                <a href="#" v-on:click="showTrainInfo(liveboard.TrainNo)">{{ liveboard.TrainNo }}</a> 車次
                 {{ getTrainTypeByID(liveboard.TrainClassificationID) }}
               </div>
               <div class="col list-group-item-right-col">
@@ -104,7 +104,7 @@
       </div>
 
       <hr class="transparent">
-      
+
       <button type="button" class="btn btn-outline-primary view-timetable-btn" v-on:click="getDailyTimetable" v-if="!this.$store.state.timetable.length">查看時刻表</button>
 
       <div class="time-table-datagrid" v-else>
@@ -119,7 +119,7 @@
             </div>
           </div>
         </div>
-        
+
         <table class="table table-striped">
           <thead class="thead-inverse">
             <tr>
@@ -134,7 +134,7 @@
           <tbody>
             <tr v-for="train in this.$store.state.timetable" v-if="train.Direction == timetableDirection">
               <td>{{ train.TrainNo }}</td>
-              <td>{{ train.TrainClassificationName.Zh_tw.replace(/\(.+\)/g, '') }}</td>
+              <td>{{ train.TrainClassificationName | trainClass }} </td>
               <td>{{ train.ArrivalTime }}</td>
               <td>{{ train.DepartureTime }}</td>
               <td>{{ train.StartingStationName }}</td>
@@ -162,7 +162,7 @@
           </div>
         </div>
       </div>
-    
+
     </div>
   </div>
 


### PR DESCRIPTION
Hi, 您取得來自 PTX 提供的車種資料，有些地方會因為 `{Zh_tw: ""}` 是空白的關係
而導致車種變成空白 （尤其是部份莒光號）

![2017-11-20 01 20 55](https://user-images.githubusercontent.com/4393788/32993328-67845e68-cd91-11e7-91f3-bf5ebf6f1183.png)

這個問題在[我的專案](https://github.com/banqhsia/tra-info) 中也有出現過，
已經幫您新增一個 `filter` 處理車種的字串了 

如果 `Zh_tw` 欄位為空白，則取用 `En` 欄位。
